### PR TITLE
feat: add proof exporters and resonance deck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,12 +32,18 @@ jobs:
       - name: Tests (pytest)
         run: pytest
 
-      - name: Upload sample artifacts
+      - name: Build Day-2 artifacts (proof + resonance)
+        run: |
+          python demo_day2.py --proof --resonance
+
+      - name: Upload artifacts (images, CSV, Lean, TeX)
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: sample-capsules
+          name: day2-artifacts
           path: |
-            capsules/*.json
-            capsules/*.ndjson
-          if-no-files-found: ignore
+            docs/resonance_wave.png
+            docs/resonance_states.csv
+            docs/proof_lean_sketch.lean
+            docs/proof_draft.tex
+          if-no-files-found: warn

--- a/README.md
+++ b/README.md
@@ -30,3 +30,29 @@ Next (Week-2 hints)
 •add --export-lean & --export-tex in a proof/ module
 •add resonance_deck.py PNG wave + CSV states
 •add quantum/qubo_exporter.py stub + adapter interface
+
+## Day-2: Proof exporters + Resonance Deck
+
+### Proof exporters
+- `brain_engine/proof/export_lean.py` emits a minimal Lean4 skeleton from a Capsule.
+- `brain_engine/proof/export_tex.py` emits a LaTeX draft page.
+- `brain_engine/proof/entropy_collapse_bridge.py` converts motif votes → SAT-ish shape and ∆Φ gates.
+
+Run:
+```bash
+python demo_day2.py --proof
+```
+
+Artifacts: docs/proof_lean_sketch.lean, docs/proof_draft.tex
+
+### Resonance Deck
+- `brain_engine/resonance/resonance_deck.py` plots ∆Φ waveform and writes a CSV of entropy states.
+
+Run:
+```bash
+python demo_day2.py --resonance
+```
+
+Artifacts: docs/resonance_wave.png, docs/resonance_states.csv
+
+CI uploads the PNG/CSV/Lean/TeX as artifacts on every push.

--- a/brain_engine/__init__.py
+++ b/brain_engine/__init__.py
@@ -1,1 +1,1 @@
-__all__ = ["glyphs", "capsule", "emit"]
+__all__ = ["glyphs", "capsule", "emit", "proof", "resonance"]

--- a/brain_engine/proof/__init__.py
+++ b/brain_engine/proof/__init__.py
@@ -1,0 +1,10 @@
+from .entropy_collapse_bridge import gates_from_delta_phi, sat_shape_from_motifs
+from .export_lean import lean_from_capsule
+from .export_tex import tex_from_capsule
+
+__all__ = [
+    "gates_from_delta_phi",
+    "sat_shape_from_motifs",
+    "lean_from_capsule",
+    "tex_from_capsule",
+]

--- a/brain_engine/proof/entropy_collapse_bridge.py
+++ b/brain_engine/proof/entropy_collapse_bridge.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+
+def _votes(motifs: list[str]) -> dict[str, int]:
+    table: dict[str, dict[str, bool]] = {
+        "collapse_warning::distort": {"np_wall": True,  "no_recovery": True,  "sat_shape": False},
+        "reversal::clean":           {"np_wall": False, "no_recovery": False, "sat_shape": True},
+        "volatility_surge::texture": {"np_wall": True,  "no_recovery": False, "sat_shape": False},
+        "stabilization::drone":      {"np_wall": False, "no_recovery": True,  "sat_shape": True},
+    }
+    v = {"np_wall": 0, "no_recovery": 0, "sat_shape": 0}
+    for m in motifs:
+        row = table.get(m, {"np_wall": False, "no_recovery": False, "sat_shape": False})
+        for k, b in row.items():
+            v[k] += (1 if b else -1)
+    return v
+
+
+def sat_shape_from_motifs(motifs: list[str]) -> bool:
+    """Return a crude SAT-ish shape by motif voting."""
+    v = _votes(motifs)
+    return v["sat_shape"] >= 0
+
+
+def gates_from_delta_phi(
+    delta: list[float],
+    *,
+    thr: float = 0.045,
+    recov_window: int = 8,
+) -> tuple[bool, bool]:
+    """Return (np_wall, no_recovery)."""
+    if not delta:
+        return (False, False)
+    np_wall = max(delta) > thr
+    last_spike = max((i for i, x in enumerate(delta) if x > thr), default=-1)
+    if last_spike < 0:
+        return (np_wall, False)
+    tail = delta[last_spike + 1 : last_spike + 1 + recov_window]
+    no_recovery = bool(tail) and all(x > thr for x in tail)
+    return (np_wall, no_recovery)

--- a/brain_engine/proof/export_lean.py
+++ b/brain_engine/proof/export_lean.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def lean_from_capsule(cap: dict[str, Any]) -> str:
+    """
+    Emit a tiny Lean4 sketch capturing verdict shape.
+    Not a proof—just a scaffold you can extend with mathlib later.
+    """
+    cid = cap.get("capsule_id", "CAP-UNKNOWN")
+    claim = cap.get("claim", "OPEN")
+    _delta = cap.get("delta_phi_series", [])  # retained for future refinements
+    motifs = cap.get("motifs", [])
+    meta = cap.get("metadata", {})
+
+    return f"""-- Auto-generated sketch from capsule {cid}
+-- claim: {claim}
+-- motifs: {motifs}
+-- pde_strength: {meta.get('pde_strength', 'n/a')}
+
+import Mathlib
+
+/--
+Entropy collapse shape scaffold:
+- monotone-ish or spike-and-hold indicates SAT or NP wall behavior
+- Replace 'admit' with proper lemmas once data constraints are formalized.
+--/
+theorem entropy_wall_or_sat_shape : Prop := by
+  -- outline: examine ∆Φ structure and motif votes (external CSV / JSON)
+  admit
+"""

--- a/brain_engine/proof/export_tex.py
+++ b/brain_engine/proof/export_tex.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from html import escape
+from typing import Any, cast
+
+
+def tex_from_capsule(cap: dict[str, Any]) -> str:
+    cid = escape(str(cap.get("capsule_id", "CAP-UNKNOWN")))
+    claim = escape(str(cap.get("claim", "OPEN")))
+    motifs = ", ".join(cast(list[str], cap.get("motifs", [])))
+    pde = cap.get("metadata", {}).get("pde_strength", "n/a")
+
+    return r"""\documentclass{article}
+\usepackage[margin=1in]{geometry}
+\begin{document}
+\section*{Entropy Collapse Capsule}
+\textbf{Capsule ID}: """ + cid + r"""\\
+\textbf{Claim}: """ + claim + r"""\\
+\textbf{Motifs}: """ + motifs + r"""\\
+\textbf{PDE Strength}: """ + str(pde) + r"""\\
+
+\subsection*{Notes}
+This is an auto-generated draft from the Brain-Engine SDK.
+Replace with formal analysis once the data constraints are fixed.
+
+\end{document}
+"""

--- a/brain_engine/resonance/__init__.py
+++ b/brain_engine/resonance/__init__.py
@@ -1,0 +1,3 @@
+from .resonance_deck import render_resonance_wave, write_states_csv
+
+__all__ = ["render_resonance_wave", "write_states_csv"]

--- a/brain_engine/resonance/resonance_deck.py
+++ b/brain_engine/resonance/resonance_deck.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+# Important: Day-2 constraint → use matplotlib (single plot, no style/colors)
+import matplotlib.pyplot as plt
+
+
+def _state(delta: float, collapse_thr: float = 0.85, recursive_thr: float = 0.45) -> str:
+    if delta >= collapse_thr:
+        return "collapse"
+    if delta >= recursive_thr:
+        return "recursive"
+    return "stable"
+
+
+def render_resonance_wave(delta_phi_series: list[float], out_png: str | Path) -> Path:
+    """Render a simple waveform of ∆Φ over index."""
+    out = Path(out_png)
+    out.parent.mkdir(parents=True, exist_ok=True)
+
+    xs = list(range(len(delta_phi_series)))
+    ys = delta_phi_series
+
+    plt.figure()
+    plt.plot(xs, ys)  # no explicit colors/styles per constraints
+    plt.title("Resonance Wave (∆Φ)")
+    plt.xlabel("Index")
+    plt.ylabel("Delta Phi")
+    plt.savefig(out, dpi=160, bbox_inches="tight")
+    plt.close()
+    return out
+
+
+def write_states_csv(delta_phi_series: list[float], out_csv: str | Path) -> Path:
+    """Write CSV of per-sample entropy states (stable/recursive/collapse)."""
+    out = Path(out_csv)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    with out.open("w", newline="", encoding="utf-8") as f:
+        w = csv.writer(f)
+        w.writerow(["index", "delta_phi", "state"])
+        for i, v in enumerate(delta_phi_series):
+            w.writerow([i, f"{v:.6f}", _state(v)])
+    return out

--- a/demo_day2.py
+++ b/demo_day2.py
@@ -1,0 +1,58 @@
+import argparse
+import json
+from pathlib import Path
+
+from brain_engine.capsule import Capsule
+from brain_engine.proof import (
+    gates_from_delta_phi,
+    lean_from_capsule,
+    sat_shape_from_motifs,
+    tex_from_capsule,
+)
+from brain_engine.resonance import render_resonance_wave, write_states_csv
+
+
+def sample_series() -> list[float]:
+    # toy series with a recursive rise; tweak to test collapse branch
+    return [0.02, 0.03, 0.05, 0.12, 0.36, 0.52, 0.61, 0.44, 0.40]
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--proof", action="store_true")
+    ap.add_argument("--resonance", action="store_true")
+    args = ap.parse_args()
+
+    delta = sample_series()
+    motifs = ["reversal::clean", "volatility_surge::texture"]
+
+    cap = Capsule.new(motifs=motifs, delta_phi_series=delta, meta={"pde_strength": 0.44})
+
+    Path("docs").mkdir(exist_ok=True)
+    Path("capsules").mkdir(exist_ok=True)
+    (Path("capsules") / "day2_capsule.json").write_text(cap.to_json(), encoding="utf-8")
+
+    if args.proof:
+        np_wall, no_recovery = gates_from_delta_phi(delta, thr=0.045, recov_window=5)
+        sat_like = sat_shape_from_motifs(motifs)
+
+        cap.metadata.update({
+            "np_wall": np_wall,
+            "no_recovery": no_recovery,
+            "sat_shape": sat_like,
+        })
+
+        lean = lean_from_capsule(json.loads(cap.to_json()))
+        tex = tex_from_capsule(json.loads(cap.to_json()))
+        Path("docs/proof_lean_sketch.lean").write_text(lean, encoding="utf-8")
+        Path("docs/proof_draft.tex").write_text(tex, encoding="utf-8")
+        print("Wrote Lean/TeX exporters → docs/")
+
+    if args.resonance:
+        render_resonance_wave(delta, "docs/resonance_wave.png")
+        write_states_csv(delta, "docs/resonance_states.csv")
+        print("Wrote Resonance Deck → docs/")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_proof_exports.py
+++ b/tests/test_proof_exports.py
@@ -1,0 +1,26 @@
+import json
+
+from brain_engine.capsule import Capsule
+from brain_engine.proof import (
+    gates_from_delta_phi,
+    lean_from_capsule,
+    sat_shape_from_motifs,
+    tex_from_capsule,
+)
+
+
+def test_proof_exports_basic() -> None:
+    delta = [0.01, 0.02, 0.5]
+    motifs = ["reversal::clean"]
+    cap = Capsule.new(motifs=motifs, delta_phi_series=delta, meta={"pde_strength": 0.44})
+    np_wall, no_rec = gates_from_delta_phi(delta, thr=0.045, recov_window=2)
+    assert np_wall is True
+    assert no_rec in (True, False)
+
+    sat_like = sat_shape_from_motifs(motifs)
+    assert isinstance(sat_like, bool)
+
+    lean = lean_from_capsule(json.loads(cap.to_json()))
+    tex = tex_from_capsule(json.loads(cap.to_json()))
+    assert "theorem entropy_wall_or_sat_shape" in lean
+    assert r"\section*{Entropy Collapse Capsule}" in tex

--- a/tests/test_resonance_deck.py
+++ b/tests/test_resonance_deck.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+from brain_engine.resonance import render_resonance_wave, write_states_csv
+
+
+def test_resonance_outputs(tmp_path: Path) -> None:
+    series = [0.01, 0.5, 0.9]
+    png = render_resonance_wave(series, tmp_path / "wave.png")
+    csv = write_states_csv(series, tmp_path / "states.csv")
+    assert png.exists()
+    assert csv.exists()
+    assert csv.read_text(encoding="utf-8").count("\n") >= 3  # header + 3 rows


### PR DESCRIPTION
## Summary
- export Lean and LaTeX sketches from capsules via new proof module
- render resonance waveforms and states CSV
- run Day-2 demo and upload artifacts in CI

## Testing
- `ruff check .`
- `mypy .`
- `pytest`
- `python demo_day2.py --proof --resonance`


------
https://chatgpt.com/codex/tasks/task_e_68c7de775d3483208f4554a604ec236e